### PR TITLE
Corrected port on README.md examples to the default Bolt port of 7687

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install --save neode
 // index.js
 import Neode from 'neode';
 
-const instance = new Neode('bolt://localhost:7474', 'username', 'password');
+const instance = new Neode('bolt://localhost:7687', 'username', 'password');
 ```
 
 #### Enterprise Mode
@@ -32,7 +32,7 @@ To initiate Neode in enterprise mode and enable enterprise features, provide a t
 // index.js
 import Neode from 'neode';
 
-const instance = new Neode('bolt://localhost:7474', 'username', 'password', true);
+const instance = new Neode('bolt://localhost:7687', 'username', 'password', true);
 ```
 
 #### Usage with .env variables


### PR DESCRIPTION
Files Affected: ./README.md

As the default bolt port for Neo4J is 7687, and Neode uses bolt primarily, I've submitted this pull request suggesting that the examples in the Readme file use bolt://localhost:7687 instead of bolt://localhost:7474 (which is the REST api port) 

