### PR TITLE
Fix `index` usage in schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ instance.model('Person', {
     },
     name: {
         type: 'name',
-        indexed: true, // Creates an Index
+        index: true, // Creates an Index
     },
     age: 'number' // Simple schema definition of property : type
 });


### PR DESCRIPTION
This caused me some confusion until I read through the Schema test cases.