### PR TITLE
Update package.json to have MIT License

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/adam-cowley/neode.git"
   },
   "author": "Adam Cowley <github@adamcowley.co.uk>",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "dotenv": "^4.0.0",
     "joi": "^13.6.0",


### PR DESCRIPTION
I noticed on npm your package said it was ISC licensed. Then I looked for a license file here on GitHub, and it appears you put an MIT license file. So, I'm just guessing the ISC license in package.json was a mistake,  because ISC is the default license when you `npm init`. Either way at least one of them should change, so just letting you know.