### PR TITLE
convert {param} syntax to

### DIFF
--- a/build/Query/Builder.js
+++ b/build/Query/Builder.js
@@ -287,7 +287,7 @@ var Builder = function () {
                 var right = this._addWhereParameter(left, value);
 
                 this._params[right] = value;
-                this._where.append(new _Where2.default(left, operator, '{' + right + '}'));
+                this._where.append(new _Where2.default(left, operator, '$' + right));
             }
 
             return this;

--- a/src/Query/Builder.js
+++ b/src/Query/Builder.js
@@ -188,7 +188,7 @@ export default class Builder {
             const right = this._addWhereParameter(left, value);
 
             this._params[ right ] = value;
-            this._where.append(new Where(left, operator, `{${right}}`));
+            this._where.append(new Where(left, operator, `$${right}`));
         }
 
         return this;

--- a/src/Query/WhereBetween.js
+++ b/src/Query/WhereBetween.js
@@ -14,7 +14,7 @@ export default class WhereBetween {
     toString() {
         const negative = this._negative ? 'NOT ' : '';
 
-        return `${negative}{${this._floor}} <= ${this._alias} <= {${this._ceiling}}`;
+        return `${negative}$${this._floor} <= ${this._alias} <= $${this._ceiling}`;
     }
 
 }

--- a/src/Query/WhereId.js
+++ b/src/Query/WhereId.js
@@ -12,6 +12,6 @@ export default class WhereId {
 
     toString() {
         const negative = this._negative ? 'NOT ' : '';
-        return `${negative}id(${this._alias}) = {${this._param}}`;
+        return `${negative}id(${this._alias}) = $${this._param}`;
     }
 }

--- a/src/Services/DeleteRelationship.js
+++ b/src/Services/DeleteRelationship.js
@@ -1,7 +1,7 @@
 export default function DeleteRelationship(neode, identity) {
     const query = `
         MATCH ()-[rel]->() 
-        WHERE id(rel) = {identity} 
+        WHERE id(rel) = $identity
         DELETE rel
     `;
 

--- a/src/Services/RelateTo.js
+++ b/src/Services/RelateTo.js
@@ -25,7 +25,7 @@ export default function RelateTo(neode, from, to, relationship, properties, forc
                 set += 'SET ';
                 set += Object.keys(properties).map(key => {
                     params[`set_${key}`] = properties[ key ];
-                    return `rel.${key} = {set_${key}}`;
+                    return `rel.${key} = $set_${key}`;
                 }).join(', ');
             }
 
@@ -33,8 +33,8 @@ export default function RelateTo(neode, from, to, relationship, properties, forc
 
             const query = `
                 MATCH (from), (to)
-                WHERE id(from) = {from_id}
-                AND id(to) = {to_id}
+                WHERE id(from) = $from_id
+                AND id(to) = $to_id
                 ${mode} (from)${direction_in}-[rel:${type}]-${direction_out}(to)
                 ${set}
                 RETURN rel

--- a/src/Services/UpdateNode.js
+++ b/src/Services/UpdateNode.js
@@ -3,8 +3,8 @@ import Validator from './Validator';
 export default function UpdateNode(neode, model, identity, properties) {
     const query = `
         MATCH (node)
-        WHERE id(node) = {identity}
-        SET node += {properties}
+        WHERE id(node) = $identity
+        SET node += $properties
         RETURN properties(node) as properties
     `;
 

--- a/src/Services/UpdateRelationship.js
+++ b/src/Services/UpdateRelationship.js
@@ -3,8 +3,8 @@ import Validator from './Validator';
 export default function UpdateRelationship(neode, model, identity, properties) {
     const query = `
         MATCH ()-[rel]->() 
-        WHERE id(rel) = {identity} 
-        SET rel += {properties} 
+        WHERE id(rel) = $identity
+        SET rel += $properties
         RETURN properties(rel) as properties
     `;
 

--- a/test/Model.spec.js
+++ b/test/Model.spec.js
@@ -167,7 +167,7 @@ describe('Model.js', () => {
                         .then(res => {
                             expect( res.get('updated') ).to.be.true;
 
-                            return instance.cypher('MATCH ()-[r]->() WHERE id(r) = {id} RETURN r.updated AS updated', { id: res.identity() })
+                            return instance.cypher('MATCH ()-[r]->() WHERE id(r) = $id RETURN r.updated AS updated', { id: res.identity() })
                                 .then(( {records} ) => {
                                     expect( records[0].get('updated') ).to.be.true;
 
@@ -179,7 +179,7 @@ describe('Model.js', () => {
                     return relationship.delete();
                 })
                 .then(res => {
-                    return instance.cypher('MATCH ()-[r]->() WHERE id(r) = {id} RETURN r', { id: res.identity() })
+                    return instance.cypher('MATCH ()-[r]->() WHERE id(r) = $id RETURN r', { id: res.identity() })
                         .then(res => {
                             expect( res.records.length ).to.equal(0);
                         });

--- a/test/Query/Builder.spec.js
+++ b/test/Query/Builder.spec.js
@@ -53,7 +53,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (id(this) = {where_this_id}) ',
+                'WHERE (id(this) = $where_this_id) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -77,10 +77,10 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (id(this) = {where_this_id}) ',
+                'WHERE (id(this) = $where_this_id) ',
                 'MATCH',
                 '(that:QueryBuilderTest)',
-                'WHERE (id(that) = {where_that_id}) ',
+                'WHERE (id(that) = $where_that_id) ',
                 'RETURN',
                 'this,that'
             ].join('\n');
@@ -103,7 +103,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -125,7 +125,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -147,7 +147,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -180,7 +180,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property} AND this.other_property = {where_this_other_property}) ',
+                'WHERE (this.property = $where_this_property AND this.other_property = $where_this_other_property) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -205,7 +205,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property} AND this.other_property = {where_this_other_property}) ',
+                'WHERE (this.property = $where_this_property AND this.other_property = $where_this_other_property) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -230,7 +230,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property} AND this.other_property = {where_this_other_property}) ',
+                'WHERE (this.property = $where_this_property AND this.other_property = $where_this_other_property) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -273,7 +273,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) OR (this.other_property = {where_this_other_property}) ',
+                'WHERE (this.property = $where_this_property) OR (this.other_property = $where_this_other_property) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -297,7 +297,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this',
                 'SKIP 1',
@@ -324,12 +324,12 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (id(this) = {where_this_id}) ',
+                'WHERE (id(this) = $where_this_id) ',
                 'WITH this',
                 '',
                 'MATCH',
                 '(that:QueryBuilderTest)',
-                'WHERE (id(that) = {where_that_id}) ',
+                'WHERE (id(that) = $where_that_id) ',
                 'RETURN',
                 'this,that'
             ].join('\n');
@@ -355,7 +355,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this',
                 'ORDER BY',
@@ -385,7 +385,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this',
                 'ORDER BY',
@@ -414,7 +414,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this',
                 'ORDER BY',
@@ -443,7 +443,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this',
                 'ORDER BY',
@@ -472,7 +472,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (this.property = {where_this_property}) ',
+                'WHERE (this.property = $where_this_property) ',
                 'RETURN',
                 'this',
                 'ORDER BY',
@@ -734,7 +734,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (NOT this.name = {where_this_name}) ',
+                'WHERE (NOT this.name = $where_this_name) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -755,7 +755,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (NOT this.name = {where_this_name} AND NOT this.name = {where_this_name_2}) ',
+                'WHERE (NOT this.name = $where_this_name AND NOT this.name = $where_this_name_2) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -775,7 +775,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE ({where_this_age_floor} <= this.age <= {where_this_age_ceiling}) ',
+                'WHERE ($where_this_age_floor <= this.age <= $where_this_age_ceiling) ',
                 'RETURN',
                 'this'
             ].join('\n');
@@ -795,7 +795,7 @@ describe('Query/Builder.js', () => {
             const expected = [
                 'MATCH',
                 '(this:QueryBuilderTest)',
-                'WHERE (NOT {where_this_age_floor} <= this.age <= {where_this_age_ceiling}) ',
+                'WHERE (NOT $where_this_age_floor <= this.age <= $where_this_age_ceiling) ',
                 'RETURN',
                 'this'
             ].join('\n');

--- a/test/Services/CleanValue.spec.js
+++ b/test/Services/CleanValue.spec.js
@@ -85,7 +85,7 @@ describe('Services/CleanValue.js', () => {
             expect(output.hour).to.equal(input.getHours());
             expect(output.minute).to.equal(input.getMinutes());
             expect(output.second).to.equal(input.getSeconds());
-            expect(output.timeZoneOffsetSeconds).to.equal(Math.abs(input.getTimezoneOffset()) * 60);
+            expect(output.timeZoneOffsetSeconds).to.equal(Math.abs(input.getTimezoneOffset()) * -60);
         });
 
         it('should handle a DateTime as a timestamp', () => {
@@ -100,7 +100,7 @@ describe('Services/CleanValue.js', () => {
             expect(output.hour).to.equal(input.getHours());
             expect(output.minute).to.equal(input.getMinutes());
             expect(output.second).to.equal(input.getSeconds());
-            expect(output.timeZoneOffsetSeconds).to.equal(Math.abs(input.getTimezoneOffset()) * 60);
+            expect(output.timeZoneOffsetSeconds).to.equal(Math.abs(input.getTimezoneOffset()) * -60);
         });
     });
 
@@ -145,7 +145,7 @@ describe('Services/CleanValue.js', () => {
             expect(output.minute).to.equal(input.getMinutes());
             expect(output.second).to.equal(input.getSeconds());
             expect(output.nanosecond).to.equal(input.getMilliseconds() * 1000000);
-            expect(output.timeZoneOffsetSeconds).to.equal(Math.abs(input.getTimezoneOffset()) * 60);
+            expect(output.timeZoneOffsetSeconds).to.equal(Math.abs(input.getTimezoneOffset()) * -60);
         });
 
         it('should handle a Time as a timestamp', () => {
@@ -158,7 +158,7 @@ describe('Services/CleanValue.js', () => {
             expect(output.minute).to.equal(input.getMinutes());
             expect(output.second).to.equal(input.getSeconds());
             expect(output.nanosecond).to.equal(input.getMilliseconds() * 1000000);
-            expect(output.timeZoneOffsetSeconds).to.equal(Math.abs(input.getTimezoneOffset()) * 60);
+            expect(output.timeZoneOffsetSeconds).to.equal(Math.abs(input.getTimezoneOffset()) * -60);
         });
     });
 

--- a/test/Services/Validator.spec.js
+++ b/test/Services/Validator.spec.js
@@ -341,7 +341,7 @@ describe('Services/Validator.js', () => {
                         },
                     });
 
-                    Validator(instance, model, { date: neo4j.types.DateTime.fromStandardDate( new Date('2020-01-01') ) })
+                    Validator(instance, model, { date: neo4j.types.DateTime.fromStandardDate( new Date('9999-01-01') ) })
                         .then(() => {
                             assert(false, 'Should fail validation');
                         })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -275,7 +275,7 @@ describe('index.js', () => {
                 })
                 .then(rel => {
                     return instance.cypher(
-                        'MATCH (start)-[rel]->(end) WHERE id(start) = {start} AND id(rel) = {rel} AND id(end) = {end} RETURN count(*) as count',
+                        'MATCH (start)-[rel]->(end) WHERE id(start) = $start AND id(rel) = $rel AND id(end) = $end RETURN count(*) as count',
                         {
                             start: rel.startNode().identity(),
                             rel: rel.identity(),
@@ -326,7 +326,7 @@ describe('index.js', () => {
                 })
                 .then(rel => {
                     return instance.cypher(
-                        `MATCH (start)-[:${ rel.type() }]->(end) WHERE id(start) = {start} AND id(end) = {end} RETURN count(*) as count`,
+                        `MATCH (start)-[:${ rel.type() }]->(end) WHERE id(start) = $start AND id(end) = $end RETURN count(*) as count`,
                         {
                             start: rel.startNode().identity(),
                             rel: rel.identity(),


### PR DESCRIPTION
Address the issue found in #94.

There are still a number of tests that don't pass from a clean `git pull` but they are unrelated to the cypher query syntax.  