### PR TITLE
Added serialization groups

### DIFF
--- a/build/Entity.js
+++ b/build/Entity.js
@@ -124,7 +124,7 @@ var Entity = /*#__PURE__*/function () {
       var output = {};
       var model = this._model || this._definition;
       model.properties().forEach(function (property, key) {
-        if (!property.hidden() && _this._properties.has(key)) {
+        if (_this._properties.has(key)) {
           output[key] = _this.valueToJson(property, _this._properties.get(key));
         }
       });

--- a/build/Node.js
+++ b/build/Node.js
@@ -170,7 +170,7 @@ var Node = /*#__PURE__*/function (_Entity) {
 
   }, {
     key: "toJson",
-    value: function toJson() {
+    value: function toJson(group) {
       var _this4 = this;
 
       var output = {
@@ -180,6 +180,10 @@ var Node = /*#__PURE__*/function (_Entity) {
 
       this._model.properties().forEach(function (property, key) {
         if (property.hidden()) {
+          return;
+        }
+
+        if (group && property.groups().length > 0 && property.groups().indexOf(group) === -1) {
           return;
         }
 
@@ -233,7 +237,7 @@ var Node = /*#__PURE__*/function (_Entity) {
 
         if (_this4._eager.has(rel.name())) {
           // Call internal toJson function on either a Node or NodeCollection
-          return _this4._eager.get(rel.name()).toJson().then(function (value) {
+          return _this4._eager.get(rel.name()).toJson(group).then(function (value) {
             return {
               key: key,
               value: value

--- a/build/Property.js
+++ b/build/Property.js
@@ -13,7 +13,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 /**
  *  Container holding information for a property.
- * 
+ *
  * TODO: Schema validation to enforce correct data types
  */
 var Property = /*#__PURE__*/function () {
@@ -29,7 +29,8 @@ var Property = /*#__PURE__*/function () {
     }
 
     this._name = name;
-    this._schema = schema; // TODO: Clean Up
+    this._schema = schema;
+    this._serialization = {}; // TODO: Clean Up
 
     Object.keys(schema).forEach(function (key) {
       _this['_' + key] = schema[key];
@@ -79,7 +80,12 @@ var Property = /*#__PURE__*/function () {
   }, {
     key: "hidden",
     value: function hidden() {
-      return this._hidden;
+      return this._serialization.hidden || false;
+    }
+  }, {
+    key: "groups",
+    value: function groups() {
+      return this._serialization.groups || [];
     }
   }, {
     key: "readonly",

--- a/build/Relationship.js
+++ b/build/Relationship.js
@@ -132,7 +132,7 @@ var Relationship = /*#__PURE__*/function (_Entity) {
 
   }, {
     key: "toJson",
-    value: function toJson() {
+    value: function toJson(group) {
       var _this2 = this;
 
       var output = {
@@ -143,6 +143,10 @@ var Relationship = /*#__PURE__*/function (_Entity) {
 
       definition.properties().forEach(function (property, key) {
         if (property.hidden()) {
+          return;
+        }
+
+        if (group && property.groups().length > 0 && property.groups().indexOf(group) === -1) {
           return;
         }
 

--- a/build/Services/Validator.js
+++ b/build/Services/Validator.js
@@ -32,7 +32,7 @@ var joi_options = {
   abortEarly: false
 }; // TODO: Move these to constants and validate the model schemas a bit better
 
-var ignore = ['labels', 'type', 'default', 'alias', 'properties', 'primary', 'relationship', 'target', 'direction', 'eager', 'hidden', 'readonly', 'index', 'unique', 'cascade'];
+var ignore = ['labels', 'type', 'default', 'alias', 'properties', 'primary', 'relationship', 'target', 'direction', 'eager', 'serialization', 'readonly', 'index', 'unique', 'cascade'];
 var booleans = ['optional', 'forbidden', 'strip', 'positive', 'negative', 'port', 'integer', 'iso', 'isoDate', 'insensitive', 'required', 'truncate', 'creditCard', 'alphanum', 'token', 'hex', 'hostname', 'lowercase', 'uppercase'];
 var booleanOrOptions = ['email', 'ip', 'uri', 'base64', 'normalize', 'hex'];
 

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -88,7 +88,7 @@ export default class Entity {
         const model = this._model || this._definition;
 
         model.properties().forEach((property, key) => {
-            if ( !property.hidden() && this._properties.has(key) ) {
+            if ( this._properties.has(key) ) {
                 output[ key ] = this.valueToJson(property, this._properties.get( key ));
             }
         });

--- a/src/Node.js
+++ b/src/Node.js
@@ -110,7 +110,7 @@ export default class Node extends Entity {
      *
      * @return {Promise}
      */
-    toJson() {
+    toJson(group) {
         const output = {
             _id: this.id(),
             _labels: this.labels(),
@@ -119,6 +119,10 @@ export default class Node extends Entity {
         // Properties
         this._model.properties().forEach((property, key) => {
             if ( property.hidden() ) {
+                return;
+            }
+
+            if ( group && (property.groups().length > 0 && property.groups().indexOf(group) === -1) ) {
                 return;
             }
 
@@ -156,7 +160,7 @@ export default class Node extends Entity {
 
             if ( this._eager.has( rel.name() ) ) {
                 // Call internal toJson function on either a Node or NodeCollection
-                return this._eager.get( rel.name() ).toJson()
+                return this._eager.get( rel.name() ).toJson(group)
                     .then(value => {
                         return { key, value };
                     });

--- a/src/Property.js
+++ b/src/Property.js
@@ -1,6 +1,6 @@
 /**
  *  Container holding information for a property.
- * 
+ *
  * TODO: Schema validation to enforce correct data types
  */
 export default class Property {
@@ -11,6 +11,7 @@ export default class Property {
 
         this._name = name;
         this._schema = schema;
+        this._serialization = {};
 
         // TODO: Clean Up
         Object.keys(schema).forEach(key => {
@@ -51,7 +52,11 @@ export default class Property {
     }
 
     hidden() {
-        return this._hidden;
+        return this._serialization.hidden || false;
+    }
+
+    groups() {
+        return this._serialization.groups || [];
     }
 
     readonly() {

--- a/src/Relationship.js
+++ b/src/Relationship.js
@@ -77,7 +77,7 @@ export default class Relationship extends Entity {
      *
      * @return {Promise}
      */
-    toJson() {
+    toJson(group) {
         const output = {
             _id: this.id(),
             _type: this.type(),
@@ -88,6 +88,10 @@ export default class Relationship extends Entity {
         // Properties
         definition.properties().forEach((property, key) => {
             if ( property.hidden() ) {
+                return;
+            }
+
+            if ( group && (property.groups().length > 0 && property.groups().indexOf(group) === -1) ) {
                 return;
             }
 

--- a/src/Services/Validator.js
+++ b/src/Services/Validator.js
@@ -23,7 +23,7 @@ const ignore = [
     'target',
     'direction',
     'eager',
-    'hidden',
+    'serialization',
     'readonly',
     'index',
     'unique',


### PR DESCRIPTION
I added a property for serialization management. For a given object, we need to select different properties to add in json serialization for diffent use cases. For exemple, I may need to add add property if the logged in user is an admin.

The schema is updated as follow. For each property, the hidden option is deplaced in an object :
```
"myProperty": {
  type: "string",
  serialization: {
    hidden: false,
    groups: ['admin']
  }
}
```
Please note that I have not updated the README as the "hidden" option was not mentionned. I do not have written any automatic test either.
