### PR TITLE
Serialization groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,3 +614,40 @@ Dropping the schema will remove all indexes and constraints created by Neode.  A
 instance.schema.drop()
     .then(() => console.log('Schema dropped!'))
 ```
+
+## Serialization
+You can use the asynchrone function toJson() to serialize any node or relation obtained with a query.
+
+### Basic use
+```javascript
+instance.findById('Person', 1)
+    .then(person => return person.toJson())
+    .then(jsonPerson => console.log(jsonPerson));
+```
+
+### Hide elements
+You can choose to hide any property during serialization by using the "hidden" property in your scheme. It is also possible to control advanced use cases by passing a serialization group to the toJson() function.
+
+```javascript
+// models/Person.js
+module.exports = {
+  id: {
+    type: 'uuid',
+    primary: true
+  },
+  propertyToHide: {
+    type: 'string',
+    hidden: true
+  },
+  propertyOnlyForAdmin: {
+    type: 'string',
+    hidden: ['anonymous_user', 'basic_user']
+  }
+}
+```
+
+```javascript
+instance.findById('Person', 1)
+    .then(person => return person.toJson('anonymous_user'))
+    .then(jsonPerson => console.log(jsonPerson)); // propertyToHide and propertyOnlyForAdmin properties will not be visible
+```

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -88,7 +88,7 @@ export default class Entity {
         const model = this._model || this._definition;
 
         model.properties().forEach((property, key) => {
-            if ( !property.hidden() && this._properties.has(key) ) {
+            if ( this._properties.has(key) ) {
                 output[ key ] = this.valueToJson(property, this._properties.get( key ));
             }
         });

--- a/src/Model.js
+++ b/src/Model.js
@@ -187,6 +187,8 @@ export default class Model extends Queryable {
 
     /**
      * Get array of hidden fields
+     * Please note only properties always hidden are returned from this method
+     * Hidden values depanding on serialization context are not taken into account
      *
      * @return {String[]}
      */

--- a/src/Node.js
+++ b/src/Node.js
@@ -125,7 +125,7 @@ export default class Node extends Entity {
      *
      * @return {Promise}
      */
-    toJson() {
+    toJson(group) {
         const output = {
             _id: this.id(),
             _labels: this.labels(),
@@ -133,7 +133,7 @@ export default class Node extends Entity {
 
         // Properties
         this._model.properties().forEach((property, key) => {
-            if ( property.hidden() ) {
+            if ( property.hidden(group) ) {
                 return;
             }
 
@@ -171,7 +171,7 @@ export default class Node extends Entity {
 
             if ( this._eager.has( rel.name() ) ) {
                 // Call internal toJson function on either a Node or NodeCollection
-                return this._eager.get( rel.name() ).toJson()
+                return this._eager.get( rel.name() ).toJson(group)
                     .then(value => {
                         return { key, value };
                     });

--- a/src/Property.js
+++ b/src/Property.js
@@ -1,6 +1,6 @@
 /**
  *  Container holding information for a property.
- * 
+ *
  * TODO: Schema validation to enforce correct data types
  */
 export default class Property {
@@ -50,8 +50,12 @@ export default class Property {
         return this._primary || this._protected;
     }
 
-    hidden() {
-        return this._hidden;
+    hidden(group) {
+        if ( Array.isArray(this._hidden) && this._hidden.indexOf(group) !== -1) {
+            return true;
+        }
+
+        return this._hidden || false;
     }
 
     readonly() {

--- a/src/Relationship.js
+++ b/src/Relationship.js
@@ -77,7 +77,7 @@ export default class Relationship extends Entity {
      *
      * @return {Promise}
      */
-    toJson() {
+    toJson(group) {
         const output = {
             _id: this.id(),
             _type: this.type(),
@@ -87,7 +87,7 @@ export default class Relationship extends Entity {
 
         // Properties
         definition.properties().forEach((property, key) => {
-            if ( property.hidden() ) {
+            if ( property.hidden(group) ) {
                 return;
             }
 

--- a/test/Model.spec.js
+++ b/test/Model.spec.js
@@ -28,6 +28,10 @@ describe('Model.js', () => {
             unique: true,
             required: true,
         },
+        stringToHide: {
+            type: 'string',
+            hidden: ['toHide']
+        },
         relationship: {
             type: 'relationship',
             relationship: 'RELATIONSHIP',
@@ -100,6 +104,9 @@ describe('Model.js', () => {
 
             expect( model.properties().get('number').readonly() ).to.equal(true);
             expect( model.properties().get('number').hidden() ).to.equal(true);
+
+            expect( model.properties().get('stringToHide').hidden('toHide') ).to.equal(true);
+            expect( model.properties().get('stringToHide').hidden('anyOtherGroup') ).to.equal(false);
 
             expect( model.hidden() ).to.deep.equal(['number']);
 


### PR DESCRIPTION
Hi @adam-cowley, I come back after a long time to continue my work. I finally deleted my old PR and made a new branch from your last master version. I modified what I did to use reuse the hidden property :

    hidden: true to hide for all
    hidden: ['group1', 'group2'] to hide property for specified group(s)

I made a test and updated the documentation but it would be great if you could check on your side too.