### PR TITLE
Added Type Definition for detachFrom()

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1037,6 +1037,15 @@ declare namespace Neode {
     delete(): Promise<Node<T>>;
 
     /**
+     * Detach this node to another
+     *
+     * @param  {Node} node Node to detach from
+     * @return {Promise}
+     */
+     // TODO I do not know what this returns
+    detachFrom(other): Promise<any>;
+
+    /**
      * Relate this node to another based on the type
      *
      * @param  {Node}   node            Node to relate to

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1039,11 +1039,10 @@ declare namespace Neode {
     /**
      * Detach this node to another
      *
-     * @param  {Node} node Node to detach from
-     * @return {Promise}
+     * @param  {Node<any>} other Node to detach from
+     * @return {Promise<[Node<any>, Node<any>]>}
      */
-     // TODO I do not know what this returns
-    detachFrom(other): Promise<any>;
+    detachFrom(other: Node<any>): Promise<[Node<any>, Node<any>]>;
 
     /**
      * Relate this node to another based on the type

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1037,7 +1037,7 @@ declare namespace Neode {
     delete(): Promise<Node<T>>;
 
     /**
-     * Detach this node to another
+     * Detach this node from another
      *
      * @param  {Node<any>} other Node to detach from
      * @return {Promise<[Node<any>, Node<any>]>}
@@ -1076,7 +1076,7 @@ declare namespace Neode {
      * @constructor
      * @param  {Neode} neode    Neode Instance
      * @param  {Node[]} values  Array of Node
-     * @return {Collectiob}
+     * @return {Collection}
      */
     constructor(neode: Neode, values: Array<Node<any>>);
 
@@ -1086,6 +1086,11 @@ declare namespace Neode {
      * @return {Int}
      */
     length: number;
+
+    /**
+     * Iterator
+     */
+    [Symbol.iterator](): IterableIterator<Node<any>>;
 
     /**
      * Get a value by it's index


### PR DESCRIPTION
The `detachFrom()` node function was missing from the types. The function docs only specify a `Promise` as a return so I'm not sure what type it returns exactly. Left it as returning `Promise<any>` and a `TODO` message.

Really needed this for use with typescript.