### PR TITLE
Adds missing localdatetime temporal type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -277,7 +277,7 @@ declare namespace Neode {
 
   type PropertyType = string | number | boolean;
 
-  type TemporalPropertyTypes = 'datetime' | 'date' | 'time' | 'localdate' | 'localtime' | 'duration'
+  type TemporalPropertyTypes = 'datetime' | 'date' | 'time' | 'localdatetime' | 'localdate' | 'localtime' | 'duration'
   type NumberPropertyTypes = 'number' | 'int' | 'integer' | 'float'
   type RelationshipPropertyTypes = 'relationship' | 'relationships'
   type NodesPropertyTypes = 'node' | 'nodes'


### PR DESCRIPTION
Per the documentation, localdatetime should be present, however TemporalPropertyTypes currently excludes it. 