### PR TITLE
update constraint syntax

### DIFF
--- a/src/Schema.js
+++ b/src/Schema.js
@@ -1,7 +1,7 @@
 
 
 function UniqueConstraintCypher(label, property, mode = 'CREATE') {
-    return `${mode} CONSTRAINT ON (model:${label}) ASSERT model.${property} IS UNIQUE`;
+    return `${mode} CONSTRAINT FOR (model:${label}) REQUIRE model.${property} IS UNIQUE`;
 }
 
 function ExistsConstraintCypher(label, property, mode = 'CREATE') {


### PR DESCRIPTION
### Why?

Currently neode generates outdated CYPHER query syntax for unique constraints.
View issue here --> https://github.com/adam-cowley/neode/issues/183


### What?

in `/src/Schema.js` update to correct CONSTRAINT syntax. Replace `ON` with `FOR` and `ASSERT` with `REQUIRE`

```ts
function UniqueConstraintCypher(label, property, mode = 'CREATE') {
    // return `${mode} CONSTRAINT ON (model:${label}) ASSERT model.${property} IS UNIQUE`;
    return `${mode} CONSTRAINT FOR (model:${label}) REQUIRE model.${property} IS UNIQUE`;
}
```